### PR TITLE
Add ccp_alpha hyperparameter to DecisionTree and RandomForest models …

### DIFF
--- a/model_runner.py
+++ b/model_runner.py
@@ -3,7 +3,7 @@ import numpy as np
 from sklearn.linear_model import LinearRegression
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
-from sklearn.metrics import mean_absolute_error, r2_score, root_mean_squared_error
+from sklearn.metrics import mean_absolute_error, r2_score, mean_squared_error
 from helpers import preprocess_data, prepare_future_dates, write_predictions
 
 
@@ -22,6 +22,7 @@ models = {
         max_depth=5,
         min_samples_split=10,
         min_samples_leaf=5,
+        ccp_alpha=0.01,  # Added ccp_alpha parameter
         random_state=42
     ),
     "Random Forest": RandomForestRegressor(
@@ -29,6 +30,7 @@ models = {
         max_depth=10,
         min_samples_split=10,
         min_samples_leaf=5,
+        ccp_alpha=0.01,  # Added ccp_alpha parameter
         random_state=42
     ),
     "Gradient Boosting": GradientBoostingRegressor(
@@ -52,8 +54,8 @@ for model_name, model in models.items():
     # Model performance on training data
     y_train_predictor = model.predict(X_train)
 
-    # Use root_mean_squared_error to evaluate the model
-    rmse = root_mean_squared_error(y_train, y_train_predictor)
+    # Use mean_squared_error to calculate RMSE
+    rmse = np.sqrt(mean_squared_error(y_train, y_train_predictor))
     mae = mean_absolute_error(y_train, y_train_predictor)
     r2 = r2_score(y_train, y_train_predictor)
 
@@ -79,3 +81,4 @@ for model_name, model in models.items():
     # Save predictions to a CSV file
     output_path = rf'D:\Python\Projects\Expense Predictor\future_predictions_{model_name.replace(" ", "_").lower()}.csv'
     write_predictions(predicted_df, output_path)
+    


### PR DESCRIPTION
…for post-pruning

This update introduces the ccp_alpha parameter to the DecisionTreeRegressor and RandomForestRegressor models, enabling post-pruning to control model complexity and reduce overfitting. By adding ccp_alpha=0.01, we provide a mechanism to prune nodes with low importance, leading to a simpler, more generalizable model. The value can be further tuned based on performance needs.

Additionally, replaced the use of root_mean_squared_error, which is not available in Scikit-learn, with mean_squared_error and adjusted the RMSE calculation accordingly. This ensures compatibility with Scikit-learn’s API and maintains accurate performance metrics.