### PR TITLE
Add max_features hyperparameter to RandomForestRegressor and Gradient…

### DIFF
--- a/model_runner.py
+++ b/model_runner.py
@@ -29,6 +29,7 @@ models = {
         max_depth=10,
         min_samples_split=10,
         min_samples_leaf=5,
+        max_features="auto",  # Add max_features parameter
         random_state=42
     ),
     "Gradient Boosting": GradientBoostingRegressor(
@@ -37,10 +38,10 @@ models = {
         max_depth=5,
         min_samples_split=10,
         min_samples_leaf=5,
+        max_features="sqrt",  # Add max_features parameter
         random_state=42
     ),
 }
-
 
 # Loop through models and evaluate
 for model_name, model in models.items():


### PR DESCRIPTION
…BoostingRegressor models

This commit introduces the `max_features` hyperparameter to the `RandomForestRegressor` and `GradientBoostingRegressor` models in the model configuration. The addition of `max_features` improves model control over the number of features considered for splits at each node, enhancing training efficiency and potentially improving model accuracy.

Changes:
- Updated `RandomForestRegressor` to use `max_features="auto"`, allowing it to consider the square root of the feature count for splits.
- Updated `GradientBoostingRegressor` to use `max_features="sqrt"`, similarly limiting the features per split.

These modifications address the missing hyperparameter warning for `max_features` in both models and are expected to optimize performance on large feature sets.