### PR TITLE
Remove hard-coded absolute paths

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ numpy
 pandas
 scikit-learn
 xlrd
--e "D:\\My Scripts"


### PR DESCRIPTION
Fixes #37

Changes:
- Replaced hard-coded Windows paths with relative paths in model_runner.py
- Added command-line arguments for configurable paths:
  - --data_file: Path to transaction CSV (default: trandata.csv)
  - --log_dir: Directory for log files (default: logs/)
  - --output_dir: Directory for prediction outputs (default: current dir)
- Updated --excel_dir default from absolute path to current directory
- Removed hard-coded editable install path from requirements.txt
- All paths now support both absolute and relative paths
- Script automatically creates necessary directories (logs, output)

The project is now portable across different systems and environments.