### PR TITLE
fix: remove redundant column rename operation in helpers.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the Expense Predictor project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2025-11-14
+
+### Fixed
+
+- **Inconsistent Column Renaming** ([#41](https://github.com/manoj-bhaskaran/expense-predictor/issues/41))
+  - Fixed duplicate column rename operation in `preprocess_and_append_csv` function (helpers.py:187-189)
+  - Removed redundant second rename that attempted to rename an already-renamed column
+  - The bug caused silent failures when processing Excel data with non-standard column names
+  - Column is now correctly renamed once from the detected column name to VALUE_DATE_LABEL
+
 ## [1.0.2] - 2025-11-14
 
 ### Fixed
@@ -182,6 +192,7 @@ When reporting issues, please include:
 
 ---
 
+[1.0.3]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.3
 [1.0.2]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.2
 [1.0.1]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.1
 [1.0.0]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.0

--- a/helpers.py
+++ b/helpers.py
@@ -186,7 +186,6 @@ def preprocess_and_append_csv(file_path, excel_path=None, logger=None):
         # Rename to standard VALUE_DATE_LABEL for consistency in downstream processing
         if value_date_col != VALUE_DATE_LABEL:
             excel_data = excel_data.rename(columns={value_date_col: VALUE_DATE_LABEL})
-            excel_data = excel_data.rename(columns={value_date_col: 'Value Date'})
 
         # Find the actual column names with flexible matching
         withdrawal_col = find_column_name(excel_data.columns, 'Withdrawal Amount (INR )')


### PR DESCRIPTION
Fixed inconsistent column renaming bug in preprocess_and_append_csv function. The second rename operation was attempting to rename a column that had already been renamed in the previous line, causing a silent failure.

Changes:
- Removed duplicate rename operation at helpers.py:189
- Column is now correctly renamed once from detected name to VALUE_DATE_LABEL
- Updated CHANGELOG.md for version 1.0.3

Fixes #41