### PR TITLE
refactor: remove redundant elif condition in model_runner.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Expense Predictor project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2025-11-14
+
+### Changed
+
+- **Code Quality** ([#43](https://github.com/manoj-bhaskaran/expense-predictor/issues/43))
+  - Removed redundant condition in model_runner.py:74
+  - Simplified `elif not args.excel_file:` to `else:` for cleaner code
+  - No functional changes, improves code readability
+
 ## [1.0.4] - 2025-11-14
 
 ### Fixed
@@ -212,6 +221,7 @@ When reporting issues, please include:
 
 ---
 
+[1.0.5]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.5
 [1.0.4]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.4
 [1.0.3]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.3
 [1.0.2]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.2

--- a/model_runner.py
+++ b/model_runner.py
@@ -71,7 +71,7 @@ else:
 
 if args.excel_file:
     excel_path = os.path.join(args.excel_dir, args.excel_file)
-elif not args.excel_file:
+else:
     excel_path = None
 
 TRANSACTION_AMOUNT_LABEL = 'Tran Amt'


### PR DESCRIPTION
Simplified the conditional logic by replacing `elif not args.excel_file:` with `else:` since the condition is redundant. This improves code readability without changing functionality.

Changes:
- Replaced redundant elif with else in model_runner.py:74
- Updated CHANGELOG.md for version 1.0.5

Fixes #43