### PR TITLE
Make magic numbers configurable in helpers.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to the Expense Predictor project will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-11-14
+
+### Added
+
+- **Configuration System** ([#44](https://github.com/manoj-bhaskaran/expense-predictor/issues/44))
+  - Added `config.yaml` file for centralizing all configurable parameters
+  - Created `config.py` module to load and manage configuration
+  - All magic numbers and hyperparameters are now configurable without code changes
+  - Configuration includes detailed comments explaining each parameter
+  - Graceful fallback to sensible defaults if config.yaml is missing or invalid
+
+- **Configurable Parameters**
+  - **Data Processing**: `skiprows` (default: 12) - customizable for different bank statement formats
+  - **Model Evaluation**: `test_size` (default: 0.2) and `random_state` (default: 42)
+  - **Decision Tree**: All hyperparameters (max_depth, min_samples_split, min_samples_leaf, ccp_alpha, random_state)
+  - **Random Forest**: All hyperparameters (n_estimators, max_depth, min_samples_split, min_samples_leaf, max_features, ccp_alpha, random_state)
+  - **Gradient Boosting**: All hyperparameters (n_estimators, learning_rate, max_depth, min_samples_split, min_samples_leaf, max_features, random_state)
+
+### Changed
+
+- **Code Structure**
+  - Refactored model_runner.py to load hyperparameters from configuration (model_runner.py:97-131)
+  - Refactored helpers.py to load skiprows from configuration (helpers.py:174)
+  - Added PyYAML dependency to requirements.txt
+
+### Documentation
+
+- Updated README.md with comprehensive configuration documentation
+  - Added new "Configuration" section explaining config.yaml usage
+  - Added "Model Tuning" section with tips for hyperparameter optimization
+  - Updated project structure to include config.py and config.yaml
+  - Enhanced troubleshooting section with configuration-related issues
+
+### Improved
+
+- **User Experience**: Users can now tune model parameters without editing code
+- **Maintainability**: All magic numbers centralized in one location
+- **Flexibility**: Easy to experiment with different hyperparameter combinations
+- **Documentation**: Each parameter in config.yaml includes explanatory comments
+
 ## [1.0.5] - 2025-11-14
 
 ### Changed
@@ -221,6 +261,7 @@ When reporting issues, please include:
 
 ---
 
+[1.1.0]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.1.0
 [1.0.5]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.5
 [1.0.4]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.4
 [1.0.3]: https://github.com/manoj-bhaskaran/expense-predictor/releases/tag/v1.0.3

--- a/README.md
+++ b/README.md
@@ -49,7 +49,40 @@ pip install -r requirements-dev.txt
 
 ## Configuration
 
-The project can be configured using command-line arguments. No environment variables are strictly required, but you can create a `.env` file based on `.env.example` for custom default paths.
+The project supports two types of configuration:
+
+### 1. Model and Data Processing Configuration (config.yaml)
+
+The `config.yaml` file allows you to customize model hyperparameters and data processing settings without modifying code. This file is automatically loaded when the application starts.
+
+**Configuration Categories:**
+
+- **Data Processing**: Control Excel file parsing (e.g., `skiprows` for bank statements)
+- **Model Evaluation**: Set train/test split ratio and random seed for reproducibility
+- **Model Hyperparameters**: Fine-tune each machine learning model's parameters
+
+**Example configuration:**
+```yaml
+data_processing:
+  skiprows: 12  # Number of header rows to skip in Excel files
+
+model_evaluation:
+  test_size: 0.2      # 20% of data for testing
+  random_state: 42    # Seed for reproducibility
+
+decision_tree:
+  max_depth: 5
+  min_samples_split: 10
+  # ... more parameters
+```
+
+See `config.yaml` for the complete list of configurable parameters with detailed explanations.
+
+**Note:** If `config.yaml` is missing or invalid, the system will use sensible defaults and continue running.
+
+### 2. Runtime Configuration (Command-Line Arguments)
+
+Command-line arguments control file paths and runtime behavior. No environment variables are strictly required, but you can create a `.env` file based on `.env.example` for custom default paths.
 
 ## Usage
 
@@ -129,6 +162,8 @@ Each file contains:
 expense-predictor/
 ├── model_runner.py          # Main script for model training and prediction
 ├── helpers.py               # Helper functions for data preprocessing
+├── config.py                # Configuration loader module
+├── config.yaml              # Configuration file for hyperparameters
 ├── requirements.txt         # Production dependencies
 ├── requirements-dev.txt     # Development dependencies
 ├── .env.example            # Example environment configuration
@@ -191,6 +226,23 @@ The project follows PEP 8 style guidelines. Use a linter to check code quality:
 flake8 model_runner.py helpers.py
 ```
 
+## Model Tuning
+
+To improve prediction accuracy, you can tune the model hyperparameters in `config.yaml`:
+
+1. **Adjust test_size**: Change the train/test split ratio (default: 0.2)
+2. **Tune Decision Tree**: Modify `max_depth`, `min_samples_split`, etc.
+3. **Tune Random Forest**: Adjust `n_estimators`, `max_depth`, etc.
+4. **Tune Gradient Boosting**: Change `learning_rate`, `n_estimators`, etc.
+
+After modifying `config.yaml`, simply run the script again - no code changes needed!
+
+**Tips for tuning:**
+- Lower `max_depth` values prevent overfitting
+- Higher `min_samples_split` and `min_samples_leaf` create simpler models
+- Increase `n_estimators` for better performance (at the cost of training time)
+- Lower `learning_rate` (with more estimators) often improves generalization
+
 ## Troubleshooting
 
 ### Common Issues
@@ -201,11 +253,14 @@ flake8 model_runner.py helpers.py
 **Issue**: `ValueError: Incorrect date format`
 - **Solution**: Ensure dates are in DD/MM/YYYY format when using `--future_date`
 
-**Issue**: Import errors for `python_logging_framework`
+**Issue**: Import errors for `python_logging_framework` or `yaml`
 - **Solution**: Ensure all dependencies are installed: `pip install -r requirements.txt`
 
 **Issue**: Predictions seem inaccurate
-- **Solution**: Check that your training data has sufficient historical data (at least several months recommended). Review log files for model performance metrics.
+- **Solution**: Check that your training data has sufficient historical data (at least several months recommended). Review log files for model performance metrics. Try tuning hyperparameters in `config.yaml`.
+
+**Issue**: Different Excel file format (different skiprows)
+- **Solution**: Edit `config.yaml` and change the `skiprows` value under `data_processing` to match your bank statement format.
 
 ## Contributing
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,113 @@
+"""
+Configuration module for Expense Predictor.
+
+This module loads and provides access to configuration parameters from config.yaml.
+All configurable parameters (magic numbers, hyperparameters) are centralized here.
+"""
+
+import os
+import yaml
+
+# Get the directory where this script is located
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_FILE = os.path.join(SCRIPT_DIR, 'config.yaml')
+
+# Default configuration (used as fallback if config.yaml is not found or incomplete)
+DEFAULT_CONFIG = {
+    'data_processing': {
+        'skiprows': 12
+    },
+    'model_evaluation': {
+        'test_size': 0.2,
+        'random_state': 42
+    },
+    'decision_tree': {
+        'max_depth': 5,
+        'min_samples_split': 10,
+        'min_samples_leaf': 5,
+        'ccp_alpha': 0.01,
+        'random_state': 42
+    },
+    'random_forest': {
+        'n_estimators': 100,
+        'max_depth': 10,
+        'min_samples_split': 10,
+        'min_samples_leaf': 5,
+        'max_features': 'sqrt',
+        'ccp_alpha': 0.01,
+        'random_state': 42
+    },
+    'gradient_boosting': {
+        'n_estimators': 100,
+        'learning_rate': 0.1,
+        'max_depth': 5,
+        'min_samples_split': 10,
+        'min_samples_leaf': 5,
+        'max_features': 'sqrt',
+        'random_state': 42
+    }
+}
+
+
+def load_config():
+    """
+    Load configuration from config.yaml file.
+
+    Returns:
+        dict: Configuration dictionary with all parameters.
+              Falls back to default values if file is not found.
+    """
+    if os.path.exists(CONFIG_FILE):
+        try:
+            with open(CONFIG_FILE, 'r') as f:
+                config = yaml.safe_load(f)
+                # Merge with defaults to ensure all keys exist
+                return _merge_configs(DEFAULT_CONFIG, config)
+        except Exception as e:
+            print(f"Warning: Could not load config.yaml: {e}")
+            print("Using default configuration.")
+            return DEFAULT_CONFIG
+    else:
+        print(f"Warning: config.yaml not found at {CONFIG_FILE}")
+        print("Using default configuration.")
+        return DEFAULT_CONFIG
+
+
+def _merge_configs(default, custom):
+    """
+    Merge custom configuration with default configuration.
+
+    This ensures that if any keys are missing from the custom config,
+    the default values are used.
+
+    Parameters:
+        default (dict): Default configuration
+        custom (dict): Custom configuration from config.yaml
+
+    Returns:
+        dict: Merged configuration
+    """
+    if custom is None:
+        return default
+
+    merged = default.copy()
+    for key, value in custom.items():
+        if isinstance(value, dict) and key in merged and isinstance(merged[key], dict):
+            merged[key] = _merge_configs(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def get_config():
+    """
+    Get the configuration dictionary.
+
+    Returns:
+        dict: Configuration dictionary with all parameters.
+    """
+    return load_config()
+
+
+# Load configuration once when module is imported
+config = load_config()

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,96 @@
+# Expense Predictor Configuration File
+# This file contains all configurable parameters for the expense prediction system.
+# You can modify these values to customize the behavior of the models and data processing.
+
+# Data Processing Configuration
+data_processing:
+  # Number of rows to skip when reading Excel files (bank statement specific)
+  # Default: 12 (common for many bank statement formats)
+  skiprows: 12
+
+# Model Evaluation Configuration
+model_evaluation:
+  # Proportion of data to use for testing (0.0 to 1.0)
+  # Default: 0.2 (20% of data used for testing, 80% for training)
+  test_size: 0.2
+
+  # Random seed for reproducibility
+  # Default: 42
+  random_state: 42
+
+# Model Hyperparameters
+# These parameters control the behavior and complexity of each machine learning model
+
+# Decision Tree Regressor Configuration
+decision_tree:
+  # Maximum depth of the tree (controls model complexity)
+  # Lower values prevent overfitting, higher values allow more complex patterns
+  max_depth: 5
+
+  # Minimum samples required to split an internal node
+  # Higher values prevent overfitting by requiring more data to make splits
+  min_samples_split: 10
+
+  # Minimum samples required at a leaf node
+  # Higher values create simpler models with smoother predictions
+  min_samples_leaf: 5
+
+  # Complexity parameter for pruning (0.0 to 1.0)
+  # Higher values result in more pruning and simpler trees
+  ccp_alpha: 0.01
+
+  # Random seed for reproducibility
+  random_state: 42
+
+# Random Forest Regressor Configuration
+random_forest:
+  # Number of trees in the forest
+  # More trees generally improve performance but increase computation time
+  n_estimators: 100
+
+  # Maximum depth of each tree
+  # Lower values prevent overfitting
+  max_depth: 10
+
+  # Minimum samples required to split an internal node
+  min_samples_split: 10
+
+  # Minimum samples required at a leaf node
+  min_samples_leaf: 5
+
+  # Number of features to consider when looking for the best split
+  # Options: "sqrt" (square root of total features), "log2", or a number
+  max_features: "sqrt"
+
+  # Complexity parameter for pruning
+  ccp_alpha: 0.01
+
+  # Random seed for reproducibility
+  random_state: 42
+
+# Gradient Boosting Regressor Configuration
+gradient_boosting:
+  # Number of boosting stages (trees) to perform
+  # More stages can improve performance but risk overfitting
+  n_estimators: 100
+
+  # Learning rate (step size shrinkage)
+  # Lower values require more estimators but can improve generalization
+  # Typical range: 0.01 to 0.3
+  learning_rate: 0.1
+
+  # Maximum depth of each tree
+  # Lower values prevent overfitting
+  max_depth: 5
+
+  # Minimum samples required to split an internal node
+  min_samples_split: 10
+
+  # Minimum samples required at a leaf node
+  min_samples_leaf: 5
+
+  # Number of features to consider when looking for the best split
+  max_features: "sqrt"
+
+  # Random seed for reproducibility
+  random_state: 42

--- a/helpers.py
+++ b/helpers.py
@@ -3,6 +3,7 @@ from pandas.tseries.offsets import DateOffset
 from datetime import datetime, timedelta
 import xlrd
 import python_logging_framework as plog
+from config import config
 
 # Define constants
 TRANSACTION_AMOUNT_LABEL = 'Tran Amt'
@@ -170,7 +171,8 @@ def preprocess_and_append_csv(file_path, excel_path=None, logger=None):
         sheet_names = pd.ExcelFile(excel_path, engine=engine).sheet_names
         plog.log_info(logger, f"Available sheets: {sheet_names}")
 
-        excel_data = pd.read_excel(excel_path, sheet_name=sheet_names[0], engine=engine, skiprows=12)
+        skiprows = config['data_processing']['skiprows']
+        excel_data = pd.read_excel(excel_path, sheet_name=sheet_names[0], engine=engine, skiprows=skiprows)
         excel_data.columns = excel_data.columns.str.strip()
         plog.log_info(logger, f"Columns in the sheet: {excel_data.columns.tolist()}")
 

--- a/model_runner.py
+++ b/model_runner.py
@@ -33,6 +33,7 @@ from datetime import datetime
 import os
 import python_logging_framework as plog
 import logging
+from config import config
 
 # Get the directory where this script is located
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -89,41 +90,44 @@ else:
 #   df: Full DataFrame after preprocessing
 X, y, df = preprocess_and_append_csv(file_path, excel_path=excel_path, logger=logger)
 
-# Split data into training and test sets (80/20 split)
-# test_size=0.2 means 20% of data is used for testing
+# Split data into training and test sets (configurable split ratio)
+# test_size from config (default: 0.2 means 20% of data is used for testing)
 # shuffle=False preserves temporal order to avoid data leakage (train on past, test on future)
-# random_state=42 ensures reproducible splits
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False, random_state=42)
+# random_state from config ensures reproducible splits
+test_size = config['model_evaluation']['test_size']
+random_state = config['model_evaluation']['random_state']
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size, shuffle=False, random_state=random_state)
 plog.log_info(logger, f"Data split: {len(X_train)} training samples, {len(X_test)} test samples")
 
 # Dictionary of models to train and evaluate.
 # Each key is a model name, value is an instantiated regressor.
+# Hyperparameters are loaded from config.yaml for easy tuning.
 models = {
     "Linear Regression": LinearRegression(),
     "Decision Tree": DecisionTreeRegressor(
-        max_depth=5,
-        min_samples_split=10,
-        min_samples_leaf=5,
-        ccp_alpha=0.01,
-        random_state=42
+        max_depth=config['decision_tree']['max_depth'],
+        min_samples_split=config['decision_tree']['min_samples_split'],
+        min_samples_leaf=config['decision_tree']['min_samples_leaf'],
+        ccp_alpha=config['decision_tree']['ccp_alpha'],
+        random_state=config['decision_tree']['random_state']
     ),
     "Random Forest": RandomForestRegressor(
-        n_estimators=100,
-        max_depth=10,
-        min_samples_split=10,
-        min_samples_leaf=5,
-        max_features="sqrt",
-        ccp_alpha=0.01,
-        random_state=42
+        n_estimators=config['random_forest']['n_estimators'],
+        max_depth=config['random_forest']['max_depth'],
+        min_samples_split=config['random_forest']['min_samples_split'],
+        min_samples_leaf=config['random_forest']['min_samples_leaf'],
+        max_features=config['random_forest']['max_features'],
+        ccp_alpha=config['random_forest']['ccp_alpha'],
+        random_state=config['random_forest']['random_state']
     ),
     "Gradient Boosting": GradientBoostingRegressor(
-        n_estimators=100,
-        learning_rate=0.1,
-        max_depth=5,
-        min_samples_split=10,
-        min_samples_leaf=5,
-        max_features="sqrt",
-        random_state=42
+        n_estimators=config['gradient_boosting']['n_estimators'],
+        learning_rate=config['gradient_boosting']['learning_rate'],
+        max_depth=config['gradient_boosting']['max_depth'],
+        min_samples_split=config['gradient_boosting']['min_samples_split'],
+        min_samples_leaf=config['gradient_boosting']['min_samples_leaf'],
+        max_features=config['gradient_boosting']['max_features'],
+        random_state=config['gradient_boosting']['random_state']
     ),
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ numpy
 pandas
 scikit-learn
 xlrd
+pyyaml
 git+https://github.com/manoj-bhaskaran/My-Scripts.git@main


### PR DESCRIPTION
Fixes #44

- Added config.yaml for centralized parameter configuration
- Created config.py module to load and manage configuration
- Made skiprows configurable (default: 12) for different bank statement formats
- Made all model hyperparameters configurable without code changes
- Updated helpers.py to use configuration for skiprows
- Updated model_runner.py to use configuration for all model hyperparameters
- Added PyYAML dependency to requirements.txt
- Updated README with comprehensive configuration documentation
- Updated CHANGELOG with version 1.1.0 changes

All magic numbers are now configurable via config.yaml:
- Data processing: skiprows
- Model evaluation: test_size, random_state
- Decision Tree: max_depth, min_samples_split, min_samples_leaf, ccp_alpha, random_state
- Random Forest: n_estimators, max_depth, min_samples_split, min_samples_leaf, max_features, ccp_alpha, random_state
- Gradient Boosting: n_estimators, learning_rate, max_depth, min_samples_split, min_samples_leaf, max_features, random_state

Version: 1.1.0 (minor bump - new feature)