### PR TITLE
docs: document console entry point usage for expense-predictor comman…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2025-11-15
+
+### Documentation
+
+- **Console Entry Point Usage Documentation** ([#79](https://github.com/manoj-bhaskaran/expense-predictor/issues/79))
+  - Updated README.md with comprehensive documentation for both usage methods
+  - Added "Method 1: As an Installed Package (Recommended)" section demonstrating `expense-predictor` command
+  - Added "Method 2: As a Python Script" section for direct Python execution
+  - Updated all usage examples throughout README to prefer the console command
+  - Updated Security section examples to use `expense-predictor` command
+  - Updated Logging section examples to use `expense-predictor` command
+  - Updated Troubleshooting section examples to use `expense-predictor` command
+  - Clarified that users can run the tool either as an installed package or as a script
+
+### Notes
+
+**Breaking Changes**: None. This is a documentation-only release.
+
+**Context**:
+- Console entry point (`expense-predictor`) was defined in setup.py in v1.8.0
+- `main()` function was implemented in v1.10.0 for testability
+- Comprehensive CLI tests (21 tests) were added in v1.10.0
+- This release completes the feature by documenting the console entry point usage
+- Both execution methods remain fully supported and tested
+
+**Version Justification**:
+- Patch version bump (1.11.0 → 1.11.1) per Semantic Versioning
+- Documentation-only change with no code modifications
+- No functional changes or API modifications
+- Improves user experience by documenting existing functionality
+
 ## [1.11.0] - 2025-11-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,18 +92,38 @@ Command-line arguments control file paths and runtime behavior. No environment v
 
 ## Usage
 
-### Basic Usage
+The Expense Predictor can be run in two ways:
 
-Run the model with default settings (uses current quarter end as prediction date):
+### Method 1: As an Installed Package (Recommended)
 
+After installing the package with `pip install .` or `pip install -e .`, you can use the `expense-predictor` command:
+
+**Basic Usage:**
+```bash
+expense-predictor --data_file trandata.csv
+```
+
+**Advanced Usage:**
+```bash
+expense-predictor \
+  --future_date 31/12/2025 \
+  --data_file ./data/trandata.csv \
+  --excel_dir ./data \
+  --excel_file bank_statement.xls \
+  --log_dir ./logs \
+  --output_dir ./predictions
+```
+
+### Method 2: As a Python Script
+
+You can also run the script directly without installation:
+
+**Basic Usage:**
 ```bash
 python model_runner.py --data_file trandata.csv
 ```
 
-### Advanced Usage
-
-Specify a custom future date and additional data sources:
-
+**Advanced Usage:**
 ```bash
 python model_runner.py \
   --future_date 31/12/2025 \
@@ -289,7 +309,7 @@ logs/model_runner.py_YYYY-MM-DD_HH-MM-SS.log
 
 You can customize the log directory using the `--log_dir` command-line argument:
 ```bash
-python model_runner.py --data_file trandata.csv --log_dir ./my_logs
+expense-predictor --data_file trandata.csv --log_dir ./my_logs
 ```
 
 ### Logger Parameter
@@ -336,13 +356,13 @@ The application protects against accidental data loss:
 
 Example with confirmation prompts:
 ```bash
-python model_runner.py --data_file trandata.csv
+expense-predictor --data_file trandata.csv
 # Will prompt: "File 'future_predictions_linear_regression.csv' already exists. Overwrite? [y/N]:"
 ```
 
 Example for automated workflows (no prompts):
 ```bash
-python model_runner.py --data_file trandata.csv --skip_confirmation
+expense-predictor --data_file trandata.csv --skip_confirmation
 # Overwrites without confirmation, but still creates backups
 ```
 
@@ -563,7 +583,7 @@ After modifying `config.yaml`, simply run the script again - no code changes nee
 - **Solution**: These are security protections. Ensure you're using valid file paths without `../` patterns and that files have correct extensions (.csv, .xls, or .xlsx).
 
 **Issue**: File overwrite confirmation prompts blocking automation
-- **Solution**: Use the `--skip_confirmation` flag to disable prompts: `python model_runner.py --data_file trandata.csv --skip_confirmation`
+- **Solution**: Use the `--skip_confirmation` flag to disable prompts: `expense-predictor --data_file trandata.csv --skip_confirmation`
 
 **Issue**: Cannot find backup files
 - **Solution**: Backup files are created with timestamps in the same directory as the output file. Look for files with `.backup_YYYYMMDD_HHMMSS` suffix.

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="expense-predictor",
-    version="1.11.0",
+    version="1.11.1",
     author="Manoj Bhaskaran",
     author_email="",
     description="A machine learning-based expense prediction system",


### PR DESCRIPTION
…d (#79)

Update documentation to show both usage methods for the expense predictor:
1. As an installed package using the `expense-predictor` command (recommended)
2. As a Python script using `python model_runner.py`

Changes:
- README.md: Added comprehensive usage documentation for both methods
  - New "Method 1: As an Installed Package" section
  - New "Method 2: As a Python Script" section
  - Updated all examples throughout to prefer console command
  - Updated Security, Logging, and Troubleshooting sections
- CHANGELOG.md: Added v1.11.1 release notes
- setup.py: Bumped version to 1.11.1

The main() function was implemented in v1.10.0 and the console entry point was defined in v1.8.0, but the usage documentation was never updated. This release completes the feature by documenting how users can run the tool after installation.

No code changes - documentation only. Both usage methods remain fully supported and tested (21 CLI integration tests in place).

Fixes #79