### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Pre-commit Checks
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/manoj-bhaskaran/expense-predictor/security/code-scanning/2](https://github.com/manoj-bhaskaran/expense-predictor/security/code-scanning/2)

To fix the problem, the `permissions` key should be added to the workflow file to restrict the GITHUB_TOKEN used in the workflow. Since none of the steps require write permissions (they only check out code and run local checks), the minimal permission required is `contents: read`, which allows the workflow to access repository contents but not alter them. This can be set either at the root of the workflow yaml (recommended for this simple workflow with a single job) or at the job level. To implement the fix, add the following block after the workflow `name` at the top of `.github/workflows/pre-commit.yml`:

```yaml
permissions:
  contents: read
```

No new imports, methods, or definitions are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
