### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Tests and Coverage
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/manoj-bhaskaran/expense-predictor/security/code-scanning/1](https://github.com/manoj-bhaskaran/expense-predictor/security/code-scanning/1)

To fix the problem, an explicit `permissions` block should be added to the workflow to restrict the `GITHUB_TOKEN` to the least privileges required. Since the workflow deals with reading repository contents and, for one step, posting comments on pull requests, the best approach is to set `contents: read` at the root level, and for the job/step that requires commenting on PRs (the "Comment PR with coverage" step), allow `pull-requests: write`. This can be achieved either at the root (if all jobs need the permission) or at the job level. For clarity and minimal privilege, put `contents: read` at the workflow level and set `permissions: contents: read, pull-requests: write` just for the job that needs to post PR comments.

In this case, the whole job "test" needs to read code, and only the "Comment PR with coverage" step needs to write to PRs. But since GitHub only supports `permissions` at the workflow or job level (not at step level), and since the commenting is done only on pull_request events, but the workflow runs for `push` and `pull_request`, it's best to assign `pull-requests: write` to the job if/when needed. For simplicity, and as only one job is present, permissions can be set for the job.

The minimal change is to add:
```yaml
permissions:
  contents: read
  pull-requests: write
```
at the root (recommended if only one job), or within the "test" job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
