### PR TITLE
feat: add environment variable configuration support (#84)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,39 +1,83 @@
-# Expense Predictor Configuration
-# Copy this file to .env and customize the values as needed
+# Expense Predictor Environment Configuration
+# ===========================================
+# Copy this file to .env and customize the values for your environment
+#
+# Usage:
+#   cp .env.example .env
+#   nano .env  # Edit with your preferred values
+#
+# Priority order (highest to lowest):
+#   1. Command-line arguments (override everything)
+#   2. Environment variables (.env file)
+#   3. Configuration file (config.yaml)
+#   4. Default values
 
-# Data File Paths
-# Default path to the CSV file containing transaction data
-DATA_FILE=trandata.csv
+# Default Data File Path
+# ----------------------
+# Path to the CSV file containing transaction data
+# If not set, will use --data_file argument or default 'trandata.csv'
+# EXPENSE_PREDICTOR_DATA_FILE=./data/trandata.csv
 
-# Excel File Configuration (optional)
-# Directory where Excel bank statement files are stored
-EXCEL_DIR=.
+# Default Excel Directory
+# -----------------------
+# Directory where the Excel file is located
+# If not set, will use --excel_dir argument or default '.' (current directory)
+# EXPENSE_PREDICTOR_EXCEL_DIR=./data
 
-# Name of the Excel file to process (leave empty if not using Excel data)
-EXCEL_FILE=
+# Default Excel File Name
+# -----------------------
+# Name of the Excel file containing additional data
+# If not set, will use --excel_file argument or no Excel file
+# EXPENSE_PREDICTOR_EXCEL_FILE=bank_statement.xls
 
-# Output Configuration
-# Directory where prediction output files will be saved
-OUTPUT_DIR=.
-
+# Default Log Directory
+# ---------------------
 # Directory where log files will be saved
-LOG_DIR=logs
+# If not set, will use --log_dir argument or default 'logs'
+# EXPENSE_PREDICTOR_LOG_DIR=./logs
 
-# Prediction Settings
-# Future date for predictions (format: DD/MM/YYYY)
-# Leave empty to automatically use the end of the current quarter
-FUTURE_DATE=
+# Default Output Directory
+# ------------------------
+# Directory where prediction files will be saved
+# If not set, will use --output_dir argument or default '.' (current directory)
+# EXPENSE_PREDICTOR_OUTPUT_DIR=./predictions
 
-# Logging Configuration
-# Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
-LOG_LEVEL=INFO
+# Default Future Date for Predictions
+# ------------------------------------
+# Future date for which to predict transaction amounts
+# Format: DD/MM/YYYY (e.g., 31/12/2025)
+# If not set, will use --future_date argument or default to end of current quarter
+# EXPENSE_PREDICTOR_FUTURE_DATE=31/12/2025
 
-# Model Configuration
-# You can add model-specific parameters here if needed in future versions
-# For now, model parameters are defined in model_runner.py
+# Skip Confirmation Prompts
+# -------------------------
+# Skip confirmation prompts for overwriting files (useful for automation)
+# Set to 'true' to skip prompts, 'false' to show prompts
+# If not set, will use --skip_confirmation flag or default 'false'
+# EXPENSE_PREDICTOR_SKIP_CONFIRMATION=false
 
-# Example Usage:
-# 1. Copy this file: cp .env.example .env
-# 2. Edit .env with your specific paths and settings
-# 3. The application will read these values if present
-# 4. Command-line arguments will override these environment variables
+# Example Configurations
+# ======================
+
+# Development Environment Example:
+# --------------------------------
+# EXPENSE_PREDICTOR_DATA_FILE=./test_data/sample.csv
+# EXPENSE_PREDICTOR_LOG_DIR=./dev_logs
+# EXPENSE_PREDICTOR_OUTPUT_DIR=./dev_predictions
+# EXPENSE_PREDICTOR_SKIP_CONFIRMATION=true
+
+# Production Environment Example:
+# --------------------------------
+# EXPENSE_PREDICTOR_DATA_FILE=/data/production/transactions.csv
+# EXPENSE_PREDICTOR_EXCEL_DIR=/data/production
+# EXPENSE_PREDICTOR_LOG_DIR=/var/log/expense-predictor
+# EXPENSE_PREDICTOR_OUTPUT_DIR=/data/predictions
+# EXPENSE_PREDICTOR_FUTURE_DATE=31/12/2025
+# EXPENSE_PREDICTOR_SKIP_CONFIRMATION=true
+
+# Docker Container Example:
+# -------------------------
+# EXPENSE_PREDICTOR_DATA_FILE=/app/data/transactions.csv
+# EXPENSE_PREDICTOR_LOG_DIR=/app/logs
+# EXPENSE_PREDICTOR_OUTPUT_DIR=/app/predictions
+# EXPENSE_PREDICTOR_SKIP_CONFIRMATION=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2025-11-15
+
+### Added
+
+- **Environment Variable Configuration Support** ([#84](https://github.com/manoj-bhaskaran/expense-predictor/issues/84))
+  - Created `.env.example` file with all supported environment variables
+  - Added `python-dotenv==1.0.0` dependency for environment variable loading
+  - Implemented automatic `.env` file loading in `model_runner.py`
+  - Environment variables now provide default values for all CLI arguments
+  - Supported environment variables:
+    - `EXPENSE_PREDICTOR_DATA_FILE`: Default CSV data file path
+    - `EXPENSE_PREDICTOR_EXCEL_DIR`: Default Excel file directory
+    - `EXPENSE_PREDICTOR_EXCEL_FILE`: Default Excel file name
+    - `EXPENSE_PREDICTOR_LOG_DIR`: Default log directory
+    - `EXPENSE_PREDICTOR_OUTPUT_DIR`: Default output directory
+    - `EXPENSE_PREDICTOR_FUTURE_DATE`: Default future date for predictions
+    - `EXPENSE_PREDICTOR_SKIP_CONFIRMATION`: Skip confirmation prompts (true/false)
+  - Command-line arguments take precedence over environment variables
+  - Works seamlessly without `.env` file (uses built-in defaults)
+
+### Changed
+
+- **Configuration Priority** ([#84](https://github.com/manoj-bhaskaran/expense-predictor/issues/84))
+  - Updated configuration priority order:
+    1. Command-line arguments (highest priority)
+    2. Environment variables (.env file)
+    3. Configuration file (config.yaml)
+    4. Default values (lowest priority)
+
+### Documentation
+
+- **README.md** ([#84](https://github.com/manoj-bhaskaran/expense-predictor/issues/84))
+  - Added comprehensive "Environment Variables (.env file)" section
+  - Documented all supported environment variables with descriptions
+  - Provided example `.env` configurations for different environments
+  - Explained configuration priority order
+  - Added usage examples showing environment variable and CLI interaction
+
+- **CONTRIBUTING.md** ([#84](https://github.com/manoj-bhaskaran/expense-predictor/issues/84))
+  - Added "Configure Environment Variables" step in development setup
+  - Added "Environment Variables for Development" section in Development Tips
+  - Documented environment variable configuration workflow
+  - Added "Adding new environment variables" to documentation update checklist
+
+### Testing
+
+- **Environment Variable Tests** ([#84](https://github.com/manoj-bhaskaran/expense-predictor/issues/84))
+  - Added 11 new unit tests for environment variable loading
+  - Test individual environment variables are loaded correctly
+  - Test CLI arguments override environment variables (priority)
+  - Test application works without environment variables (defaults)
+  - Test multiple environment variables work together
+  - All tests marked with `@pytest.mark.unit` for selective execution
+
+### Improved
+
+- **Developer Experience** ([#84](https://github.com/manoj-bhaskaran/expense-predictor/issues/84))
+  - Developers can now set default paths via `.env` file
+  - Reduces need to specify command-line arguments repeatedly
+  - Supports different configurations per environment (dev, staging, prod)
+  - `.env` file already in `.gitignore` to prevent accidental commits
+
+- **Automation and CI/CD** ([#84](https://github.com/manoj-bhaskaran/expense-predictor/issues/84))
+  - Environment variables enable easier automation and scripting
+  - Docker containers can use environment variables for configuration
+  - CI/CD pipelines can set variables without modifying code
+  - `SKIP_CONFIRMATION` variable supports headless execution
+
 ## [1.13.0] - 2025-11-15
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,24 @@ pip install -r requirements.txt
 pip install -r requirements-dev.txt
 ```
 
-### 5. Verify Setup
+### 5. Configure Environment Variables (Optional)
+
+```bash
+# Copy the example environment file
+cp .env.example .env
+
+# Edit with your development settings
+nano .env
+
+# Example development .env:
+# EXPENSE_PREDICTOR_DATA_FILE=./test_data/sample.csv
+# EXPENSE_PREDICTOR_LOG_DIR=./dev_logs
+# EXPENSE_PREDICTOR_SKIP_CONFIRMATION=true
+```
+
+**Note:** The `.env` file is in `.gitignore` and will not be committed to version control. This allows each developer to have their own local configuration without affecting others.
+
+### 6. Verify Setup
 
 ```bash
 # Run tests to verify everything works
@@ -561,6 +578,7 @@ git commit -m "test(helpers): add validation tests for Excel files"
 - Fixing bugs that affect usage
 - Adding new dependencies
 - Changing configuration options
+- Adding new environment variables
 
 ### Documentation Files
 
@@ -689,6 +707,34 @@ Features are evaluated based on:
 - **Breaking Changes**: Impact on existing users
 
 ## Development Tips
+
+### Environment Variables for Development
+
+You can set environment variables in your `.env` file for easier development:
+
+```bash
+# .env file for development
+EXPENSE_PREDICTOR_DATA_FILE=./test_data/sample.csv
+EXPENSE_PREDICTOR_LOG_DIR=./dev_logs
+EXPENSE_PREDICTOR_OUTPUT_DIR=./dev_predictions
+EXPENSE_PREDICTOR_SKIP_CONFIRMATION=true
+```
+
+This allows you to run the application without specifying command-line arguments:
+
+```bash
+# Uses values from .env
+python model_runner.py
+
+# Override specific values
+python model_runner.py --data_file ./other_data.csv
+```
+
+**Priority order:**
+1. Command-line arguments (highest)
+2. Environment variables (.env file)
+3. Configuration file (config.yaml)
+4. Default values (lowest)
 
 ### Helpful Commands
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,66 @@ See `config.yaml` for the complete list of configurable parameters with detailed
 
 **Note:** If `config.yaml` is missing or invalid, the system will use sensible defaults and continue running.
 
-### 2. Runtime Configuration (Command-Line Arguments)
+### 2. Environment Variables (.env file)
 
-Command-line arguments control file paths and runtime behavior. No environment variables are strictly required, but you can create a `.env` file based on `.env.example` for custom default paths.
+The project supports environment variables for setting default values. This is useful for:
+- Setting default paths without command-line arguments
+- Configuring different environments (dev, staging, prod)
+- Keeping sensitive paths out of version control
+- Automated workflows and CI/CD pipelines
+
+**Setup:**
+
+```bash
+# Copy the example file
+cp .env.example .env
+
+# Edit with your preferred defaults
+nano .env
+```
+
+**Supported Environment Variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `EXPENSE_PREDICTOR_DATA_FILE` | Path to CSV file with transaction data | `trandata.csv` |
+| `EXPENSE_PREDICTOR_EXCEL_DIR` | Directory containing Excel file | `.` (current directory) |
+| `EXPENSE_PREDICTOR_EXCEL_FILE` | Name of Excel file with additional data | None |
+| `EXPENSE_PREDICTOR_LOG_DIR` | Directory for log files | `logs` |
+| `EXPENSE_PREDICTOR_OUTPUT_DIR` | Directory for prediction output files | `.` (current directory) |
+| `EXPENSE_PREDICTOR_FUTURE_DATE` | Future date for predictions (DD/MM/YYYY) | End of current quarter |
+| `EXPENSE_PREDICTOR_SKIP_CONFIRMATION` | Skip file overwrite confirmations (`true`/`false`) | `false` |
+
+**Example .env file:**
+
+```bash
+# Development environment
+EXPENSE_PREDICTOR_DATA_FILE=./test_data/sample.csv
+EXPENSE_PREDICTOR_LOG_DIR=./dev_logs
+EXPENSE_PREDICTOR_OUTPUT_DIR=./dev_predictions
+EXPENSE_PREDICTOR_SKIP_CONFIRMATION=true
+```
+
+**Configuration Priority (highest to lowest):**
+
+1. **Command-line arguments** - Override everything
+2. **Environment variables** - Set via `.env` file
+3. **Configuration file** - `config.yaml` settings
+4. **Default values** - Built-in defaults
+
+**Example:**
+
+```bash
+# Uses .env values for all settings
+python model_runner.py
+
+# Overrides .env data_file but uses other .env values
+python model_runner.py --data_file ./other_data.csv
+```
+
+### 3. Runtime Configuration (Command-Line Arguments)
+
+Command-line arguments provide the highest priority configuration and can override both environment variables and config file settings.
 
 ## Usage
 

--- a/model_runner.py
+++ b/model_runner.py
@@ -52,6 +52,10 @@ from security import (
     ALLOWED_CSV_EXTENSIONS,
     ALLOWED_EXCEL_EXTENSIONS
 )
+from dotenv import load_dotenv
+
+# Load environment variables from .env file (if it exists)
+load_dotenv()
 
 # Get the directory where this script is located
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -61,6 +65,18 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
     """
     Parse command-line arguments for the expense predictor.
 
+    Environment variables can be used to set default values. Command-line arguments
+    take precedence over environment variables.
+
+    Supported environment variables:
+        - EXPENSE_PREDICTOR_FUTURE_DATE: Default future date for predictions
+        - EXPENSE_PREDICTOR_EXCEL_DIR: Default Excel file directory
+        - EXPENSE_PREDICTOR_EXCEL_FILE: Default Excel file name
+        - EXPENSE_PREDICTOR_DATA_FILE: Default CSV data file path
+        - EXPENSE_PREDICTOR_LOG_DIR: Default log directory
+        - EXPENSE_PREDICTOR_OUTPUT_DIR: Default output directory
+        - EXPENSE_PREDICTOR_SKIP_CONFIRMATION: Skip confirmation prompts (true/false)
+
     Args:
         args: Optional list of arguments to parse. If None, uses sys.argv.
 
@@ -68,13 +84,48 @@ def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
         argparse.Namespace: Parsed arguments object.
     """
     parser = argparse.ArgumentParser(description='Expense Predictor')
-    parser.add_argument('--future_date', type=str, help='Future date for prediction (e.g., 31/12/2025)')
-    parser.add_argument('--excel_dir', type=str, default='.', help='Directory where the Excel file is located')
-    parser.add_argument('--excel_file', type=str, help='Name of the Excel file containing additional data')
-    parser.add_argument('--data_file', type=str, default='trandata.csv', help='Path to the CSV file containing transaction data')
-    parser.add_argument('--log_dir', type=str, default='logs', help='Directory where log files will be saved')
-    parser.add_argument('--output_dir', type=str, default='.', help='Directory where prediction files will be saved')
-    parser.add_argument('--skip_confirmation', action='store_true', help='Skip confirmation prompts for overwriting files (useful for automation)')
+    parser.add_argument(
+        '--future_date',
+        type=str,
+        default=os.getenv('EXPENSE_PREDICTOR_FUTURE_DATE'),
+        help='Future date for prediction (e.g., 31/12/2025)'
+    )
+    parser.add_argument(
+        '--excel_dir',
+        type=str,
+        default=os.getenv('EXPENSE_PREDICTOR_EXCEL_DIR', '.'),
+        help='Directory where the Excel file is located'
+    )
+    parser.add_argument(
+        '--excel_file',
+        type=str,
+        default=os.getenv('EXPENSE_PREDICTOR_EXCEL_FILE'),
+        help='Name of the Excel file containing additional data'
+    )
+    parser.add_argument(
+        '--data_file',
+        type=str,
+        default=os.getenv('EXPENSE_PREDICTOR_DATA_FILE', 'trandata.csv'),
+        help='Path to the CSV file containing transaction data'
+    )
+    parser.add_argument(
+        '--log_dir',
+        type=str,
+        default=os.getenv('EXPENSE_PREDICTOR_LOG_DIR', 'logs'),
+        help='Directory where log files will be saved'
+    )
+    parser.add_argument(
+        '--output_dir',
+        type=str,
+        default=os.getenv('EXPENSE_PREDICTOR_OUTPUT_DIR', '.'),
+        help='Directory where prediction files will be saved'
+    )
+    parser.add_argument(
+        '--skip_confirmation',
+        action='store_true',
+        default=os.getenv('EXPENSE_PREDICTOR_SKIP_CONFIRMATION', 'false').lower() == 'true',
+        help='Skip confirmation prompts for overwriting files (useful for automation)'
+    )
     return parser.parse_args(args)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,8 @@ xlrd==2.0.1
 # Configuration file support
 pyyaml==6.0.1
 
+# Environment variable loading
+python-dotenv==1.0.0
+
 # Note: python_logging_framework is included locally in the project root
 # No external installation required

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="expense-predictor",
-    version="1.12.1",
+    version="1.14.0",
     author="Manoj Bhaskaran",
     author_email="",
     description="A machine learning-based expense prediction system",
@@ -45,6 +45,7 @@ setup(
         "scikit-learn==1.5.0",
         "xlrd==2.0.1",
         "pyyaml==6.0.1",
+        "python-dotenv==1.0.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Implement environment variable loading to provide default values for CLI arguments, enabling easier configuration across different environments.

Changes:
- Created .env.example with all supported environment variables
- Added python-dotenv==1.0.0 dependency
- Updated model_runner.py to load environment variables with load_dotenv()
- Environment variables provide defaults for all CLI arguments
- CLI arguments take precedence over environment variables
- Added 11 new unit tests for environment variable functionality
- Updated documentation (README, CONTRIBUTING, CHANGELOG)
- Bumped version to 1.14.0

Supported environment variables:
- EXPENSE_PREDICTOR_DATA_FILE: Default CSV data file path
- EXPENSE_PREDICTOR_EXCEL_DIR: Default Excel file directory
- EXPENSE_PREDICTOR_EXCEL_FILE: Default Excel file name
- EXPENSE_PREDICTOR_LOG_DIR: Default log directory
- EXPENSE_PREDICTOR_OUTPUT_DIR: Default output directory
- EXPENSE_PREDICTOR_FUTURE_DATE: Default future date for predictions
- EXPENSE_PREDICTOR_SKIP_CONFIRMATION: Skip confirmation prompts

Configuration priority (highest to lowest):
1. Command-line arguments
2. Environment variables (.env file)
3. Configuration file (config.yaml)
4. Default values

Fixes #84