### PR TITLE
fix: Add openpyxl to production dependencies (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.1] - 2025-11-16
+
+### Fixed
+
+- **Missing Production Dependency** ([#106](https://github.com/manoj-bhaskaran/expense-predictor/issues/106))
+  - Added `openpyxl==3.1.2` to production dependencies in `requirements.txt`
+  - Added `openpyxl==3.1.2` to `setup.py` install_requires
+  - Resolves critical issue where .xlsx file processing failed in production installations
+  - openpyxl was previously only listed in development dependencies (requirements-dev.txt)
+  - Users can now process both .xls and .xlsx files after standard installation
+  - Runtime error `ModuleNotFoundError: No module named 'openpyxl'` resolved
+
+### Impact
+
+- **Severity**: Critical
+- **Affected Functionality**: Excel .xlsx file processing (helpers.py:105-106)
+- **User Impact**: Production installations can now process .xlsx files without manual dependency installation
+- **Breaking Changes**: None - backward compatible enhancement
+
+### Technical Details
+
+- **Files Modified**:
+  - `requirements.txt` (added openpyxl==3.1.2 with comment)
+  - `setup.py` (added openpyxl==3.1.2 to install_requires at line 48)
+  - `tests/__init__.py` (version bumped to 1.17.1)
+  - `CHANGELOG.md` (this file)
+
+- **Code Reference**:
+  - `helpers.py:105-106` uses openpyxl engine for .xlsx files
+  - Engine selection: `engine = "xlrd" if file_path.endswith(".xls") else "openpyxl"`
+  - pandas.ExcelFile() requires openpyxl for .xlsx format support
+
+### Notes
+
+**Version Justification**:
+- Patch version bump (1.17.0 → 1.17.1) per Semantic Versioning
+- Bug fix: missing dependency that broke core functionality
+- No API changes or new features
+- Backward compatible: existing code works unchanged
+
+**Migration Guide**:
+- For existing installations: `pip install -r requirements.txt` or `pip install openpyxl==3.1.2`
+- For new installations: dependencies now correctly installed automatically
+- No code changes required
+
 ## [1.17.0] - 2025-11-15
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ pandas==2.2.0
 scikit-learn==1.5.0
 
 # Excel file support
-xlrd==2.0.1
+xlrd==2.0.1  # For .xls files
+openpyxl==3.1.2  # For .xlsx files
 
 # Configuration file support
 pyyaml==6.0.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="expense-predictor",
-    version="1.17.0",
+    version="1.17.1",
     author="Manoj Bhaskaran",
     author_email="",
     description="A machine learning-based expense prediction system",
@@ -45,6 +45,7 @@ setup(
         "pandas==2.2.0",
         "scikit-learn==1.5.0",
         "xlrd==2.0.1",
+        "openpyxl==3.1.2",
         "pyyaml==6.0.1",
         "python-dotenv==1.0.0",
     ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,4 +5,4 @@ This package contains unit tests, integration tests, and test fixtures
 for the expense prediction system.
 """
 
-__version__ = "1.5.0"
+__version__ = "1.17.1"


### PR DESCRIPTION
**Summary**
- Added openpyxl==3.1.2 to requirements.txt for .xlsx file support
- Added openpyxl==3.1.2 to setup.py install_requires
- Updated version to 1.17.1 (patch version for bug fix)
- Updated CHANGELOG.md with comprehensive fix documentation

**Impact**
- Fixes critical issue where .xlsx file processing failed in production
- Resolves ModuleNotFoundError when processing Excel .xlsx files
- openpyxl was previously only in dev dependencies

**Technical Details**
- helpers.py:105-106 requires openpyxl for .xlsx file processing
- Engine selection: xlrd for .xls, openpyxl for .xlsx
- pandas.ExcelFile() requires openpyxl for .xlsx format support

Closes #106