### PR TITLE
refactor: Consolidate constants into single module (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.2] - 2025-11-16
+
+### Changed
+
+- **Consolidate Constants into Single Module** ([#110](https://github.com/manoj-bhaskaran/expense-predictor/issues/110))
+  - Created new `constants.py` module for centralized constant definitions
+  - Moved `TRANSACTION_AMOUNT_LABEL`, `VALUE_DATE_LABEL`, and `DAY_OF_WEEK` constants from helpers.py to constants.py
+  - Removed duplicate `TRANSACTION_AMOUNT_LABEL` definition from model_runner.py (line 287)
+  - Updated helpers.py to import constants from constants module
+  - Updated model_runner.py to import constants from constants module
+  - Establishes single source of truth for all constants
+  - Prevents future DRY violations and inconsistencies
+
+### Impact
+
+- **Severity**: High
+- **Type**: Code Quality / Refactoring
+- **User Impact**: No functional changes - purely internal refactoring
+- **Breaking Changes**: None - backward compatible code improvement
+- **Benefits**:
+  - Single source of truth for constants
+  - Easier maintenance and updates
+  - Reduces risk of inconsistency
+  - Improved code organization
+  - Follows Python best practices
+
+### Technical Details
+
+- **Files Added**:
+  - `constants.py` - New module containing all shared constants
+
+- **Files Modified**:
+  - `helpers.py` (removed lines 16-18, added import from constants)
+  - `model_runner.py` (removed line 287, added import from constants)
+  - `setup.py` (added constants to py_modules, version bumped to 1.18.2)
+  - `tests/__init__.py` (version bumped to 1.18.2)
+  - `CHANGELOG.md` (this file)
+
+- **Testing**:
+  - All 191 existing tests pass
+  - No test modifications required
+  - Verified constant imports work correctly
+
+### Notes
+
+**Breaking Changes**: None. This is a backward-compatible release.
+
+**Version Justification**:
+- Patch version bump (1.18.1 → 1.18.2) per Semantic Versioning
+- Internal refactoring: improves code quality without changing functionality
+- No API changes or new features
+- Backward compatible: existing code works unchanged
+
+**Migration Guide**:
+- No migration needed - purely internal refactoring
+- All imports remain compatible
+- Existing code continues to work without modification
+
+**Related Issues and PRs**:
+- Issue #110: DRY Violation: TRANSACTION_AMOUNT_LABEL Defined in Multiple Files
+
 ## [1.18.1] - 2025-11-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ expense-predictor/
 ├── helpers.py               # Helper functions for data preprocessing
 ├── security.py              # Security utilities (path validation, sanitization)
 ├── config.py                # Configuration loader module
+├── constants.py             # Centralized constants for the application
 ├── config.yaml              # Configuration file for hyperparameters
 ├── python_logging_framework.py  # Custom logging framework module
 ├── setup.py                 # Package setup and dependencies configuration

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,11 @@
+"""
+Constants used throughout the Expense Predictor application.
+
+This module centralizes all constant definitions to ensure consistency
+across the codebase and follow the DRY (Don't Repeat Yourself) principle.
+"""
+
+# Column names
+TRANSACTION_AMOUNT_LABEL = "Tran Amt"
+VALUE_DATE_LABEL = "Value Date"
+DAY_OF_WEEK = "Day of the Week"

--- a/helpers.py
+++ b/helpers.py
@@ -9,13 +9,9 @@ from pandas.tseries.offsets import DateOffset
 
 import python_logging_framework as plog
 from config import config
+from constants import DAY_OF_WEEK, TRANSACTION_AMOUNT_LABEL, VALUE_DATE_LABEL
 from exceptions import DataValidationError
 from security import confirm_overwrite, create_backup, sanitize_dataframe_for_csv
-
-# Define constants
-TRANSACTION_AMOUNT_LABEL = "Tran Amt"
-DAY_OF_WEEK = "Day of the Week"
-VALUE_DATE_LABEL = "Value Date"
 
 
 def validate_csv_file(file_path: str, logger: Optional[logging.Logger] = None) -> None:

--- a/model_runner.py
+++ b/model_runner.py
@@ -48,6 +48,7 @@ from sklearn.tree import DecisionTreeRegressor
 
 import python_logging_framework as plog
 from config import config
+from constants import TRANSACTION_AMOUNT_LABEL
 from helpers import (
     get_quarter_end_date,
     prepare_future_dates,
@@ -284,8 +285,6 @@ def train_and_evaluate_models(
         skip_confirmation: Whether to skip file overwrite confirmations.
         logger: Logger instance.
     """
-    TRANSACTION_AMOUNT_LABEL = "Tran Amt"
-
     # Dictionary of models to train and evaluate.
     models = {
         "Linear Regression": LinearRegression(),

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (this_directory / "README.md").read_text()
 
 setup(
     name="expense-predictor",
-    version="1.18.1",
+    version="1.18.2",
     author="Manoj Bhaskaran",
     author_email="",
     description="A machine learning-based expense prediction system",
@@ -22,6 +22,7 @@ setup(
         "helpers",
         "security",
         "config",
+        "constants",
         "exceptions",
         "python_logging_framework",
     ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,4 +5,4 @@ This package contains unit tests, integration tests, and test fixtures
 for the expense prediction system.
 """
 
-__version__ = "1.18.1"
+__version__ = "1.18.2"


### PR DESCRIPTION
Fixes #110 - DRY Violation: TRANSACTION_AMOUNT_LABEL Defined in Multiple Files

Changes:
- Created new constants.py module for centralized constant definitions
- Moved TRANSACTION_AMOUNT_LABEL, VALUE_DATE_LABEL, and DAY_OF_WEEK from helpers.py
- Removed duplicate TRANSACTION_AMOUNT_LABEL from model_runner.py
- Updated imports in helpers.py and model_runner.py
- Added constants to setup.py py_modules list
- Updated version to 1.18.2
- Updated CHANGELOG.md with release notes
- Updated README.md project structure

Benefits:
- Single source of truth for all constants
- Easier maintenance and updates
- Reduces risk of inconsistency
- Improved code organization
- Follows Python best practices

Testing:
- All 191 tests pass
- Verified constant imports work correctly

Version: 1.18.2
Type: Refactoring
Breaking Changes: None