### PR TITLE
Fix numpy version inconsistency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     ],
     python_requires=">=3.9",
     install_requires=[
-        "numpy==2.0.2",
+        "numpy<2,>=1.22.4",
         "pandas==2.3.3",
         "scikit-learn==1.5.0",
         "xlrd==2.0.2",


### PR DESCRIPTION
Problem:
- setup.py specified numpy==2.0.2
- requirements.txt specified numpy<2,>=1.22.4
- This inconsistency could cause dependency conflicts

Solution:
- Updated setup.py to use the same numpy constraint as requirements.txt
- Ensures consistent dependency resolution across installation methods
- Maintains compatibility with matplotlib 3.8.x

Related to model_runner.py import errors and dependency management.