### PR TITLE
fix: move permissions from workflow level to job level in security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,5 @@
 name: Security Scanning
 
-permissions:
-  contents: read
-
 on:
   pull_request:
     branches: [ main, master ]
@@ -16,6 +13,8 @@ jobs:
   bandit:
     name: Bandit Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code
@@ -48,6 +47,8 @@ jobs:
   dependency-check:
     name: Dependency Security Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Move contents:read permission from workflow level to individual job level to follow principle of least privilege. This ensures each job only has the permissions it explicitly needs, addressing SonarCloud rule S8264.